### PR TITLE
added support for larger winbond flash parts

### DIFF
--- a/fpgaprog/progalgspi.cpp
+++ b/fpgaprog/progalgspi.cpp
@@ -295,6 +295,27 @@ bool ProgAlgSpi::Spi_Identify(bool verbose)
             SectorErase=1;
             FlashType=GENERIC;
             break;
+		  case 0x16: /* W25Q32 */
+			Pages=16384;
+            PageSize=256;
+            BulkErase=10;
+            SectorErase=1;
+            FlashType=GENERIC;
+            break;
+		  case 0x17: /* W25Q64 */
+			Pages=32768;
+            PageSize=256;
+            BulkErase=10;
+            SectorErase=1;
+            FlashType=GENERIC;
+            break;			
+		  case 0x18: /* W25Q128 */
+			Pages=65536;
+            PageSize=256;
+            BulkErase=10;
+            SectorErase=1;
+            FlashType=GENERIC;
+            break;
           default:
             printf("Unknown Winbond W25Q Flash Size (0x%.2x)\n", tdo[3]);
             return false;


### PR DESCRIPTION
I have added some lines of code to add larger Winbond Flash parts (i.e. W25Q64, W25Q128).
